### PR TITLE
Added Designated Inits GCC feature

### DIFF
--- a/content/teaching/hacking-in-c-2020/assignments/index.md
+++ b/content/teaching/hacking-in-c-2020/assignments/index.md
@@ -64,6 +64,12 @@ weight = 30
 
 * [``man malloc``](http://man7.org/linux/man-pages/man3/malloc.3.html)
 * [An annotated example of local variables on the stack](https://www.cs.rutgers.edu/~pxk/419/notes/frames.html)
-* [Designated Inits for easy array initialization](https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Designated-Inits.html)
+
+#### Initializing an array with a fixed value
+
+The below code will initialize the whole of ``array`` with the value ``0x42``.
+```c
+unsigned char array[SIZE] = {0x42};
+```
 
 [Brightspace]: https://brightspace.ru.nl/d2l/home/88557

--- a/content/teaching/hacking-in-c-2020/assignments/index.md
+++ b/content/teaching/hacking-in-c-2020/assignments/index.md
@@ -64,6 +64,6 @@ weight = 30
 
 * [``man malloc``](http://man7.org/linux/man-pages/man3/malloc.3.html)
 * [An annotated example of local variables on the stack](https://www.cs.rutgers.edu/~pxk/419/notes/frames.html)
-
+* [Designated Inits for easy array initialization](https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Designated-Inits.html)
 
 [Brightspace]: https://brightspace.ru.nl/d2l/home/88557


### PR DESCRIPTION
I found this really cool way of initializing arrays. One problem is however that this will literally be hardcoded in your program so you'll have a program that has a size of ~4M:
```c
char a[SIZE] = {[0 ... SIZE-1] = TEST_BYTE};
```